### PR TITLE
Add Chapter Playbook

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -36,6 +36,17 @@ export default defineConfig({
           { text: 'Start a new chapter', link: '/new-chapter' },
           { text: 'Chapter Onboarding', link: '/chapter-onboarding' },
         ]
+      },
+      {
+        text: 'Chapter Playbook', link: '/chapter-playbook/',
+        collapsed: true,
+        items: [
+          { text: 'Onboarding a New Chapter', link: '/chapter-playbook/onboarding' },
+          { text: 'Requirements to Keep Your Chapter', link: '/chapter-playbook/requirements' },
+          { text: 'Offboarding a Chapter', link: '/chapter-playbook/offboarding' },
+          { text: 'Transferring a Chapter', link: '/chapter-playbook/transferring' },
+          { text: 'Code of Conduct', link: '/chapter-playbook/code-of-conduct' },
+        ]
       },      
       {
         text: 'Chapter Benefits', link: '/chapter-benefits/',

--- a/chapter-playbook/code-of-conduct.md
+++ b/chapter-playbook/code-of-conduct.md
@@ -1,0 +1,12 @@
+---
+outline: deep
+---
+
+# Code of Conduct
+
+All Global AI Community events (in-person meetups, virtual sessions, conferences) and online spaces (Discord, social media, etc.) are governed by the **[Global AI Community Code of Conduct](https://globalai.community/code-of-conduct/)**.
+
+- Every chapter is required to make the Code of Conduct **publicly visible**, for example linked in your Meetup page, event descriptions, or Discord server rules.
+- Organizers are responsible for enforcing the Code of Conduct at their events and in their community spaces.
+- Serious or repeated violations can trigger the [offboarding process](/chapter-playbook/offboarding) for the chapter.
+- If you need to report an incident, contact [support@globalai.community](mailto:support@globalai.community).

--- a/chapter-playbook/index.md
+++ b/chapter-playbook/index.md
@@ -1,0 +1,31 @@
+---
+outline: deep
+---
+
+# Chapter Playbook
+
+<Badge type="warning" text="Work in Progress: draft for review" />
+
+This playbook is the single reference for everything related to running a Global AI Community chapter: how to start one, what's expected of you while you run it, and what happens if a chapter needs to be handed over or closed down.
+
+Use the menu to navigate:
+
+- **[Onboarding a New Chapter](/chapter-playbook/onboarding)**: how to start a chapter and get it set up
+- **[Requirements to Keep Your Chapter](/chapter-playbook/requirements)**: what's expected of an active chapter, and what happens if requirements aren't met
+- **[Offboarding a Chapter](/chapter-playbook/offboarding)** *(Draft)*: how to close a chapter
+- **[Transferring a Chapter](/chapter-playbook/transferring)** *(Draft)*: how to hand over a chapter to a new organizer
+- **[Code of Conduct](/chapter-playbook/code-of-conduct)**: the rules that govern all chapter activity
+
+> **Note:** Pages marked *(Draft)* propose a process that does not yet exist elsewhere in our documentation. Please review these carefully, they are our best-effort recommendation based on how similar volunteer communities operate, not yet a ratified policy.
+
+## Quick Reference
+
+| I want to... | Go to |
+|---|---|
+| Start a brand new chapter | [Onboarding a New Chapter](/chapter-playbook/onboarding) |
+| Set up my chapter's tools and accounts | [Chapter Onboarding](/chapter-onboarding) |
+| Understand what's expected of me as a chapter lead | [Requirements to Keep Your Chapter](/chapter-playbook/requirements) |
+| Add or remove an organizer | [Transferring a Chapter: Partial Transfers](/chapter-playbook/transferring#partial-transfers) |
+| Hand my chapter to a new organizer | [Transferring a Chapter](/chapter-playbook/transferring) |
+| Close my chapter | [Offboarding a Chapter](/chapter-playbook/offboarding) |
+| Read the Code of Conduct | [Code of Conduct](/chapter-playbook/code-of-conduct) |

--- a/chapter-playbook/offboarding.md
+++ b/chapter-playbook/offboarding.md
@@ -1,0 +1,34 @@
+---
+outline: deep
+---
+
+# Offboarding a Chapter
+
+<Badge type="warning" text="Draft" />
+
+Offboarding is the process of formally closing a chapter, whether by choice (organizers decide to stop) or as a result of prolonged inactivity or a policy violation. The goal is to close things down respectfully, protect the community's members, and cleanly recover shared assets.
+
+## When Offboarding Applies
+
+- The organizing team chooses to stop running the chapter and no successor can be found (see [Transferring a Chapter](/chapter-playbook/transferring) first, if possible).
+- The chapter has been inactive beyond the warning grace period (see [Requirements: escalation path](/chapter-playbook/requirements#what-happens-if-requirements-aren-t-met)).
+- A serious or repeated Code of Conduct violation has occurred.
+- The chapter is found to be used for commercial or for-profit purposes.
+
+## Offboarding Checklist
+
+1. **Notify leadership.** Organizers (or leadership, in the involuntary case) formally confirm the chapter is closing via the chapter lead Discord channel or email to `support@globalai.community`.
+2. **Communicate to members.** Post a farewell/closure announcement on the chapter's Meetup, socials, and Discord, thanking the community and pointing members to nearby chapters or the global community.
+3. **Wind-down period.** Allow a short window (suggested: 30 days) for any in-flight events or commitments to be honored or cancelled gracefully.
+4. **Revoke access and hand back assets:**
+   - Chapter `@globalai.community` email account is deactivated.
+   - Ownership of the Meetup group is transferred back to the [Global AI Community Network](https://www.meetup.com/pro/the-global-ai-community/) or archived.
+   - LinkedIn Showcase page is archived or unpublished.
+   - Discord roles/permissions for the organizers are removed; the chapter's dedicated channels (if any) are archived.
+   - Any Azure/sponsor subscriptions tied to the chapter are reclaimed (see [Chapter Benefits: Azure](/chapter-benefits/azure)).
+5. **Update the record.** Leadership marks the chapter as closed in the Chapter Dashboard and removes it from public chapter listings.
+6. **Retrospective (optional but encouraged).** A short written note from the outgoing organizers on lessons learned, to help future chapters in similar cities.
+
+## Good Standing on Exit
+
+Chapters that close voluntarily and in good standing (no CoC violations, assets returned) remain eligible to apply again in the future, and former organizers are welcome to support the launch of a successor chapter.

--- a/chapter-playbook/onboarding.md
+++ b/chapter-playbook/onboarding.md
@@ -1,0 +1,41 @@
+---
+outline: deep
+---
+
+# Onboarding a New Chapter
+
+Starting a chapter is the beginning of a long-term commitment to your local AI community. Full step-by-step instructions already live in two guides, this page summarizes the journey and links out to the details.
+
+## Eligibility
+
+- Your chapter must be **local and city-based**. A second chapter in the same city may be allowed depending on circumstances.
+- You need **at least two organizers** from the start, to share the workload and avoid burnout.
+- Your chapter is not for one-off events: there's an expectation of **ongoing activity, at least once every three months**.
+- Chapters must be **not-for-profit** and free to attend.
+
+See [Start a Global AI Chapter](/new-chapter) for the full list of guidelines, benefits, and FAQs.
+
+## Step-by-step Process
+
+| Step | Action |
+|---|---|
+| 1 | Join the [Discord community](https://discord.gg/NMryZKPC3m) and introduce yourself in `#general`. Seek mentorship from existing chapter leads. |
+| 2 | [Fill in the chapter request form](https://forms.office.com/e/zQAYMdiZr0). |
+| 3 | Wait for review. Requests are reviewed once a month, the month following submission. |
+| 4 | If approved, you'll receive a welcome package with your `@globalai.community` email credentials. |
+| 5 | **Do not** purchase domains or set up email addresses yourself. Global AI Community handles this centrally for trademark and administrative reasons. |
+
+## Getting Set Up
+
+Once approved, follow [Chapter Onboarding](/chapter-onboarding) to:
+
+- Set up and start using your official chapter email
+- Join the **#new-chapter-lead** Discord channel
+- Complete your Chapter Dashboard profile (description, organizers, photos, socials)
+- Set up your LinkedIn Showcase page
+- Set up your Meetup group (see [Meetup Benefit](/chapter-benefits/meetup))
+- Review [Organisers 101](/organisers-101/) and [Branding Guidelines](/branding/) before your first event
+
+## What's Next
+
+Once onboarded, review [Requirements to Keep Your Chapter](/chapter-playbook/requirements) to understand what's expected of you going forward.

--- a/chapter-playbook/requirements.md
+++ b/chapter-playbook/requirements.md
@@ -1,0 +1,44 @@
+---
+outline: deep
+---
+
+# Requirements to Keep Your Chapter
+
+Being approved is the start, not the finish line. To stay a chapter in good standing, organizers agree to the following ongoing responsibilities (see also [Start a Chapter: Role and Responsibilities](/new-chapter#role-and-responsibilities-of-the-chapter-lead)):
+
+## 1. Stay Active
+- Organize or co-organize **at least one event every three months**.
+- You don't have to be the speaker: invite local talent and create opportunities for first-time speakers.
+
+## 2. Maintain a Team of Organizers
+- Keep **at least two organizers** at all times.
+- Notify Global AI Community leadership whenever your organizing team changes (new organizer joins, or someone steps down).
+
+## 3. Participate Globally
+- Take part in global initiatives: Global AI Bootcamp, Global AI Conference, livestreams, newsletters.
+- Relay official announcements from the leadership team to your members when asked.
+- Submit an **annual activity report** to the leadership team.
+
+## 4. Be Inclusive
+- Keep event registration open and free of charge.
+
+## 5. Keep It Safe
+- All chapter activity (events, online spaces, chats) is governed by the [Global AI Community Code of Conduct](/chapter-playbook/code-of-conduct).
+- You must make the Code of Conduct publicly visible for your chapter (e.g., linked from your Meetup page or event description).
+
+## 6. Represent the Brand Correctly
+- Use only your `@globalai.community` email for chapter business: member communication, Meetup, and social media account ownership.
+- Follow the [Branding Guidelines](/branding/) for logos, colors, and templates.
+
+## 7. Stay Not-for-Profit
+- Chapter activity must not be used for commercial purposes.
+
+## What Happens If Requirements Aren't Met? <Badge type="warning" text="Draft" />
+
+We recommend a light-touch, supportive escalation path rather than sudden shutdown:
+
+| Stage | Trigger | Action |
+|---|---|---|
+| **Check-in** | No event in 3+ months, or missing annual report | Leadership reaches out directly to understand the situation and offer support (co-organizer matching, event ideas, promotion help). |
+| **Warning** | No response to check-in, or 6+ months of inactivity | Formal written notice via chapter email, with a defined grace period (suggested: 60 days) to resume activity or start a [transfer](/chapter-playbook/transferring). |
+| **Offboarding** | No activity or response after the grace period, Code of Conduct violation, or misuse of the brand | Chapter enters the [offboarding process](/chapter-playbook/offboarding). |

--- a/chapter-playbook/transferring.md
+++ b/chapter-playbook/transferring.md
@@ -1,0 +1,42 @@
+---
+outline: deep
+---
+
+# Transferring a Chapter
+
+<Badge type="warning" text="Draft" />
+
+Sometimes a chapter doesn't need to close, it just needs new leadership. Transferring keeps the community, brand presence, and momentum intact while responsibility moves to a new organizer or team.
+
+## When to Transfer Instead of Offboarding
+
+- An organizer is stepping down but at least one other active organizer (or a willing replacement) can continue.
+- The whole team wants to step back, but a new team from within the community is ready to take over.
+- The chapter is healthy and active: only the people running it are changing.
+
+## Transfer Process
+
+1. **Identify a successor.** The outgoing organizer(s) nominate one or more incoming organizers, ideally people already engaged in the chapter (co-organizers, active volunteers, regular attendees).
+   - Minimum of **two organizers** must be in place after the transfer, per the standard chapter requirement.
+2. **Notify leadership.** Email `support@globalai.community` (or post in the chapter lead Discord channel) with:
+   - Outgoing organizer(s) name(s)
+   - Incoming organizer(s) name(s) and contact details
+   - Reason for transfer and desired timeline
+3. **Leadership review.** Global AI Community leadership confirms the incoming organizer(s) understand and accept the [chapter responsibilities](/chapter-playbook/requirements) and [Code of Conduct](/chapter-playbook/code-of-conduct).
+4. **Handover checklist:**
+   - `@globalai.community` email credentials reset and passed to the new organizer(s)
+   - Meetup group admin/organizer roles updated
+   - Discord chapter-lead channel access updated; old organizer removed, new organizer added
+   - LinkedIn Showcase page admin access updated
+   - Chapter Dashboard organizer list updated (profile, photo, socials)
+   - Any Azure subscription or other benefit ownership reassigned
+   - Sponsor/partner contacts (if any) informed of the new point of contact
+5. **Transition period.** Where possible, the outgoing organizer stays available for a short overlap window (suggested: 2–4 weeks) to answer questions and introduce the new organizer(s) to the community.
+6. **Announce the change.** Post an announcement on the chapter's Meetup/socials introducing the new organizer(s) and thanking the outgoing one(s).
+
+## Partial Transfers
+
+If only one organizer of a multi-person team is leaving and at least one remains active, this is a simpler **organizer change**, not a full transfer:
+- Notify leadership of the team change (already required under [chapter requirements](/chapter-playbook/requirements))
+- Update the Chapter Dashboard, Meetup, Discord, and LinkedIn access accordingly
+- No wind-down or successor-approval step is required


### PR DESCRIPTION
Adds a new "Chapter Playbook" section to the docs site with separate pages for:

- Onboarding a new chapter
- Requirements to keep a chapter active
- Offboarding a chapter (draft, no prior documented process)
- Transferring a chapter (draft, no prior documented process)
- Code of Conduct

The Offboarding and Transferring pages are marked as drafts since there was no existing documented process for these; they propose a reasonable process for review.