### PR TITLE
Add annual partnership proposal

### DIFF
--- a/partnerships/agentcon-sponsorship.md
+++ b/partnerships/agentcon-sponsorship.md
@@ -18,9 +18,9 @@ AgentCon events are free for attendees, attracting a minimum of **150 participan
 
 Sponsorship covers a series of AgentCon events over an agreed period. Sponsors receive the following benefits per event:
 
-### Speaking Session
-- A dedicated speaking session (25 or 45 minutes depending on the event format)
-- Optional 60-90-minute workshop, if the venue permits
+### Speaking Session or Workshop
+- A dedicated speaking session (25 or 45 minutes depending on the event format), or
+- A 60-90-minute workshop, if the venue permits
 
 ### Pre-Event Exposure
 - Listing as sponsor on the event page

--- a/partnerships/partnership-proposal.md
+++ b/partnerships/partnership-proposal.md
@@ -1,0 +1,158 @@
+---
+title: Partnership Proposal
+search: false
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
+
+# Partnership Proposal
+
+**Term:** 1 July 2026 to 1 July 2027
+
+## Executive Summary
+
+The Global AI Community connects **250,000+ members through 200+ chapters worldwide**. Our ecosystem includes a chapter and event platform, Global AI Weekly with **70,000+ subscribers**, a YouTube channel with **50,000+ subscribers**, global event programs, and local communities on every continent.
+
+This proposal gives the Partner a year-round global presence and direct engagement with AI developers through six AgentCon events. It combines:
+
+1. A complimentary annual Global AI Community Partner package with specific content, product, social, and event-platform deliverables.
+2. Six AgentCon sponsorships, qualifying the organization as a **Global AgentCon Sponsor**.
+
+The standard combined value is **€24,000**. The proposed investment is **€18,000**, with the €6,000 annual Partner fee fully waived.
+
+## Partnership Objectives
+
+The partnership is designed to:
+
+- Introduce the Partner's products and services to relevant AI developers, data scientists, students, professionals, and community leaders.
+- Create practical product experiences through credits, licenses, subscriptions, tools, services, workshops, and educational content.
+- Build sustained brand awareness through global digital channels and local in-person events.
+- Establish the Partner as an active supporter of accessible, community-led AI education.
+- Generate meaningful engagement without compromising community independence, editorial standards, or member privacy.
+
+## Proposal at a Glance
+
+| Component | Included scope | Standard price | Proposed price |
+| --- | --- | ---: | ---: |
+| Global AI Community Partner | 12-month package | €6,000 | €0 |
+| Global AgentCon Sponsor | 6 events at €3,000 each | €18,000 | €18,000 |
+| **Total** | **1 annual partnership and 6 events** | **€24,000** | **€18,000** |
+
+## 1. Annual Global AI Community Partner Package
+
+The Partner receives the following benefits for the full proposal term. These deliverables are included at no additional cost because the standard €6,000 Partner fee is waived.
+
+| Partnership benefit | Included delivery | Quantity or timing |
+| --- | --- | --- |
+| **Brand recognition** | Recognition as a Partner of the Global AI Community; logo, name, and website link on the partner page; permission to use the approved Partner designation | Full term: 1 July 2026 to 1 July 2027 |
+| **Global AI Weekly** | Partner articles featuring approved educational content, technical guidance, community programs, or product and service offers; topics and dates agreed in advance and subject to editorial review | 4 articles: one in July–September 2026, October–December 2026, January–March 2027, and April–June 2027 |
+| **Additional Global AI Weekly articles** | Additional approved articles at a 50% discount on the standard €500 rate | €250 per additional article |
+| **Short technical series** | One series about the Partner's company, product, or service; each episode provides a concise technical insight, practical tip, capability, or use case; scripts and publication dates agreed in advance | Up to 4 episodes of no more than 30 seconds each |
+| **Optional in-person interview** | An additional interview may be recorded when schedules and locations align | Optional; not a guaranteed deliverable |
+| **Global social media** | Posts across agreed Global AI Community-owned channels supporting the partnership, content, product campaign, technical series, or another agreed initiative | 4 posts during the term |
+| **Product and services campaign** | One coordinated offer of credits, vouchers, licenses, subscriptions, cloud or API access, developer tools, training resources, or professional services through agreed community channels | 1 campaign with audience, channels, timing, eligibility, and redemption process agreed before launch |
+| **Event organizing tools** | Access to public event publishing, attendee registration, capacity management, attendee communications, and digital badges | 1 approved Partner event series during the term |
+
+All content, campaign, and event-series plans require prior agreement and must align with the Global AI Community's educational mission and brand policies. The Global AI Community manages distribution and does not provide the Partner with community member contact details or mailing-list access.
+
+## 2. Global AgentCon Sponsorship
+
+The Partner will sponsor six AgentCon events selected and scheduled by mutual agreement during the proposal term. Each AgentCon is designed for at least 150 participants, creating an expected aggregate audience of at least **900 attendee places** across the six events.
+
+### Guaranteed Aggregate Deliverables
+
+Across the six sponsored AgentCon events, the Partner receives:
+
+| Deliverable | Total included |
+| --- | ---: |
+| Speaking sessions of 25 or 45 minutes, or workshops of 60 to 90 minutes when the venue permits | 6 total: one session or workshop per event |
+| Sponsor listings on event pages | 6 |
+| Content blocks in pre-event emails | 6 |
+| Social media posts announcing event sponsorship | 6 |
+| Content blocks in post-event emails | 6 |
+| Verbal sponsor acknowledgements during opening remarks | 6 |
+| Banner or small stand placements, subject to venue rules | Up to 6 |
+| Event reports | 6 |
+| Access to event photo collections | 6 |
+
+### Global AgentCon Sponsor Recognition
+
+The six-event commitment qualifies the Partner for **Global AgentCon Sponsor** status during the proposal term. This includes:
+
+- Use of the Global AgentCon Sponsor designation.
+- Logo and name recognition on the central AgentCon sponsor page.
+- Recognition in applicable program-wide AgentCon sponsor communications and materials.
+- Coordination of the six-event portfolio through Global AI Community HQ.
+
+## Delivery and Reporting
+
+The Global AI Community will maintain a delivery record for the agreed benefits. This will include:
+
+- Links to the four published Global AI Weekly articles.
+- Links to the published technical series episodes and, if produced, the optional in-person interview.
+- Links or screenshots for the four annual Partner social posts.
+- A summary of the product and services campaign and the channels used.
+- Confirmation of the approved Partner event series and enabled platform capabilities.
+- An event report and photo link for each sponsored AgentCon.
+- A final summary of delivered activities and reported aggregate AgentCon attendance.
+
+Reporting will use aggregated information only and will not include personal attendee, subscriber, or community member data.
+
+## Responsibilities
+
+### Global AI Community
+
+- Coordinate the annual Partner deliverables and six AgentCon sponsorships.
+- Agree on schedules, content topics, campaign channels, and participating events with the Partner.
+- Publish approved content and brand assets through the agreed Global AI Community channels.
+- Provide access to the agreed event organizing capabilities.
+- Review content for quality, relevance, brand compliance, and alignment with the community's educational mission.
+- Provide the delivery evidence and reports described above.
+
+### Partner
+
+- Pay the €18,000 sponsorship investment according to the written agreement.
+- Supply approved logos, brand assets, campaign details, and content materials by the agreed deadlines.
+- Provide a spokesperson, technical input, and approved materials for the short technical series and any optional in-person interview.
+- Provide speakers for all six AgentCon sessions.
+- Provide speakers or workshop facilitators and materials for the selected format at each AgentCon event.
+- Supply any physical banners, stands, or event materials.
+- Define and fulfill all product or service campaign offers, including eligibility, availability, support, and redemption terms.
+- Follow the Global AI Community Code of Conduct, sponsorship guidelines, and brand policies.
+
+## Investment
+
+The total investment for 1 July 2026 to 1 July 2027 is **€18,000**.
+
+| Item | Calculation | Price |
+| --- | ---: | ---: |
+| Six AgentCon sponsorships | 6 x €3,000 | €18,000 |
+| Annual Global AI Community Partner package | Standard price €6,000; fully waived | €0 |
+| **Total investment** |  | **€18,000** |
+
+Invoicing and payment timing will be defined in the written agreement.
+
+## Conditions and Safeguards
+
+- The parties will confirm the selected AgentCon events and schedule in writing.
+- Branding assets and session or workshop materials must be supplied at least four weeks before each event.
+- Sessions and sponsored content are subject to review for alignment with the Global AI Community's educational mission.
+- The organization must follow the Global AI Community Code of Conduct, sponsorship guidelines, and brand policies.
+- The partnership does not provide exclusivity unless explicitly stated in the written agreement.
+- The Partner does not influence editorial decisions, speaker selection, chapter governance, or community operations.
+- The Partner does not receive community member, subscriber, or attendee personal data.
+- Product or service visibility does not imply endorsement by the Global AI Community.
+- Sponsorship fees are non-refundable.
+- Event changes require mutual written agreement.
+
+## Next Steps
+
+1. Confirm acceptance of the proposed scope and €18,000 investment.
+2. Select the six AgentCon events.
+3. Agree on the Partner content calendar, product campaign, and event series.
+4. Complete the written partnership and sponsorship agreement.
+5. Schedule a kickoff meeting and begin delivery.
+
+To proceed, contact **[hq@globalai.community](mailto:hq@globalai.community)**.


### PR DESCRIPTION
## Summary
- add an unlisted annual partnership proposal with explicit deliverables
- define quarterly content, technical series, product campaign, and event tooling
- clarify that each AgentCon includes a speaking session or workshop