### PR TITLE
Restructure AgentCon for 2027

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -116,19 +116,25 @@ export default defineConfig({
               { text: 'Post-Event, Resources & Sponsors', link: '/global-ai-conference/post-event' },
             ]
           },
-          { text: 'AgentCon', link: '/agentcon/',
+          { text: 'AgentCon 2027', link: '/agentcon/',
             collapsed: true,
             items: [
-              { text: 'Eligibility and Roles', link: '/agentcon/eligibility-and-roles' },
-              { text: 'Event Overview', link: '/agentcon/event-overview' },
-              { text: 'Core Requirments', link: '/agentcon/core-requirments' },
-              { text: 'Application and Approval Process', link: '/agentcon/application-and-approval-process' },
-              { text: 'Planning Timeline', link: '/agentcon/planning-timeline' },
-              { text: 'Venue & Logistics', link: '/agentcon/venue-logistics' },
-              { text: 'Marketing, Promotion & Branding Guidelines', link: '/agentcon/marketing-promotion-branding' },
-              { text: 'Day-of-Event Playbook', link: '/agentcon/day-of-event-playbook' },
-              { text: 'Post-Event Tasks', link: '/agentcon/post-event tasks' },
-              { text: 'Appendices', link: '/agentcon/appendices' },
+              { text: 'Events', link: '/agentcon/events' },
+              { text: 'Guide', link: '/agentcon/',
+                collapsed: true,
+                items: [
+                  { text: 'Eligibility and Roles', link: '/agentcon/eligibility-and-roles' },
+                  { text: 'Event Overview', link: '/agentcon/event-overview' },
+                  { text: 'Core Requirements', link: '/agentcon/core-requirments' },
+                  { text: 'Invitation and Approval Process', link: '/agentcon/application-and-approval-process' },
+                  { text: 'Planning Timeline', link: '/agentcon/planning-timeline' },
+                  { text: 'Venue & Logistics', link: '/agentcon/venue-logistics' },
+                  { text: 'Marketing, Promotion & Branding Guidelines', link: '/agentcon/marketing-promotion-branding' },
+                  { text: 'Day-of-Event Playbook', link: '/agentcon/day-of-event-playbook' },
+                  { text: 'Post-Event Tasks', link: '/agentcon/post-event tasks' },
+                  { text: 'Appendices', link: '/agentcon/appendices' },
+                ]
+              },
               { text: 'Sponsors', link: '/agentcon/sponsors' },
             ]
           },
@@ -169,7 +175,7 @@ export default defineConfig({
               ] 
           },
           { text: 'Newsletter',link: '/partnerships/newsletter'},
-          { text: 'AgentCon Sponsorship', link: '/partnerships/agentcon-sponsorship' }
+          { text: 'AgentCon 2027 Sponsorship', link: '/partnerships/agentcon-sponsorship' }
         ]
       },      
     ],

--- a/agentcon/appendices.md
+++ b/agentcon/appendices.md
@@ -5,7 +5,8 @@ outline: deep
 
 ## Useful Links
 
-- [**Application Form**](https://gaic.io/host-agentcon/)  
+- [**AgentCon 2027 Events**](/agentcon/events)
+- [**Global AI Conference Application Process**](/global-ai-conference/application-and-timeline)
 - [**Sessionize**](https://sessionize.com/)  
 - [**Branding GitHub Repository**](https://github.com/GlobalAICommunity/AgentCon/tree/main/branding/general-branding)  
 - [**Microsoft Keynote Video**](https://www.youtube.com/watch?v=4MUgq_rzjqo)  
@@ -25,4 +26,3 @@ outline: deep
 ## Contact
 
 - **Global AI HQ:** [hq@globalai.community](mailto:hq@globalai.community)  
-

--- a/agentcon/application-and-approval-process.md
+++ b/agentcon/application-and-approval-process.md
@@ -2,28 +2,34 @@
 outline: deep
 ---
 
-# Application and Approval Process
+# Invitation and Approval Process
 
 ## Step-by-Step
 
-1. **Submit Application Form**  
-   Fill out the AgentCon Organizer Application form. Include:  
-   - Chapter name and lead contact  
-   - Proposed city and venue  
-   - Estimated date  
-   - Expected audience size  
+1. **Receive an Invitation**
+   Global AI HQ selects event locations and invites chapter leads and/or local organizers based on the 2027 event strategy, community readiness, and delivery capacity.
 
-2. **Wait for HQ Approval**  
-   HQ will verify:  
+2. **Confirm Interest and Capacity**
+   The invited co-organizing team confirms:
+   - Chapter name and lead contact
+   - Proposed city and venue
+   - Available dates
+   - Expected audience size
+   - Organizing team capacity
+
+3. **Receive Final HQ Approval**
+   HQ verifies:
    - No duplicate events in your region  
    - Venue and timeline feasibility  
    - Chapter activity status  
 
-3. **Meet with Global AI HQ**  
+4. **Meet with Global AI HQ**
    Schedule a **30–45 minute** call to review:  
    - Event plan  
    - Roles and responsibilities  
    - Support and promotional strategies  
 
-4. **Slack Setup**  
+5. **Slack Setup**
    You’ll be added to the **AgentCon Slack channel** for ongoing coordination.
+
+AgentCon 2027 does not have an open application form. Chapters seeking an open 2027 conference format should use the [Global AI Conference application process](/global-ai-conference/application-and-timeline).

--- a/agentcon/eligibility-and-roles.md
+++ b/agentcon/eligibility-and-roles.md
@@ -2,18 +2,24 @@
 outline: deep
 ---
 # Eligibility and Roles
+
 ## Who Can Organize
 
-Only **official Global AI Chapters** can organize AgentCon events. Each chapter should have:
+AgentCon 2027 is **invite-only**. Events are organized jointly by Global AI HQ and invited chapter leads and/or local organizers. Global AI HQ selects the locations and co-organizing teams; unsolicited applications are not accepted.
+
+Invited co-organizers should have:
 
 - An active organizing team (2–5 people minimum).  
 - A local network of developers and community partners.  
 - Capacity to host at least 200 attendees.  
 
+Chapters that want to organize an open conference format in 2027 should apply for the [Global AI Conference](/global-ai-conference/).
+
 ## Key Roles
 
 | **Role** | **Responsibility** |
 |-----------|--------------------|
+| **Global AI HQ** | Event ownership, location and organizer selection, central coordination, standards, sponsorship alignment, and global promotion. |
 | **Lead Organizer** | Overall event direction, coordination with HQ, and compliance with requirements. |
 | **Program Lead** | Manages CFP (Sessionize), speaker selection, and scheduling. |
 | **Logistics Lead** | Venue, catering, AV, and volunteer coordination. |

--- a/agentcon/event-overview.md
+++ b/agentcon/event-overview.md
@@ -3,13 +3,13 @@ outline: deep
 ---
 # Event Overview
 
-AgentCon follows a **fixed format** to ensure global consistency and quality.
+AgentCon 2027 follows a **fixed, invite-only format** to ensure global consistency and quality.
 
 | **Attribute** | **Requirement** |
 |----------------|-----------------|
 | **Duration** | 1 day |
 | **Hours** | 10:00–17:00 or 15:00–21:00 |
-| **Waves** | Wave 2: Sept–Dec 2025 / Wave 3: Jan–Jun 2026 |
+| **Schedule** | 2027 dates and locations assigned by invitation and agreed with Global AI HQ |
 | **Tracks** | Minimum 2 — one session track and one workshop track |
 | **Keynote** | Microsoft Keynote (45 min, speaker provided) |
 | **Audience** | Minimum 200 attendees |

--- a/agentcon/events.md
+++ b/agentcon/events.md
@@ -1,0 +1,35 @@
+# AgentCon 2027 Events
+
+AgentCon 2027 is an invite-only event series organized jointly by Global AI HQ and invited chapter leads and/or local organizers. Global AI HQ selects the locations and confirms each local co-organizing team.
+
+## Remaining Confirmed 2026 Events
+
+The following 2026 events are confirmed and available for sponsorship selection, subject to availability and written confirmation from Global AI Community HQ.
+
+| Date | Location | Venue | Time | Event |
+| --- | --- | --- | --- | --- |
+| 8 September 2026 | London, United Kingdom | London Southbank University | 09:00–17:00 | [AgentCon London](https://globalai.community/e/x79ncrl7) |
+| 3 November 2026 | Singapore | Singapore University of Technology and Design, Building 1, Albert Hong Lecture Theatre | 08:30–17:00 | [AgentCon Singapore](https://globalai.community/e/awgteae7) |
+| 12 November 2026 | Copenhagen, Denmark | To be announced | 09:30–17:00 | [AgentCon Copenhagen](https://globalai.community/e/6zkdqgv0) |
+
+For the latest confirmed events, visit the [live AgentCon event calendar](https://globalai.community/events/agentcon).
+
+_Last checked: 27 July 2026._
+
+## Proposed AgentCon 2027 Locations
+
+The following invite-only locations are being considered for AgentCon 2027 and the six-event Global AgentCon sponsorship package. Dates and locations are provisional until confirmed by Global AI HQ together with the invited chapter leads and/or local organizers.
+
+| Suggested period | Location |
+| --- | --- |
+| 30 January 2027 | Bengaluru, India |
+| 6 February 2027 | Bangkok, Thailand |
+| 3 April 2027 | Toronto, Canada |
+| 6 April 2027 | New York, United States |
+| 9 April 2027 | Silicon Valley, United States |
+| April 2027 | Ottawa, Canada |
+| May 2027 | Melbourne, Australia |
+| May 2027 | Hong Kong |
+| May 2027 | Tokyo, Japan |
+| June 2027 | Berlin, Germany |
+| June 2027 | Amsterdam, Netherlands |

--- a/agentcon/index.md
+++ b/agentcon/index.md
@@ -1,11 +1,17 @@
 ---
 outline: deep
 ---
-# AgentCon Organizer Comprehensive Guide
+# AgentCon 2027 Organizer Guide
 
 ![General logo](/media/agentcon/agentcon_banner_v3.jpg) 
 
 [AgentCon](http://agentcon.dev/) is a global developer conference focused on AI Agents, built by developers, for developers. It is part of the Global AI Community and provides hands-on learning, collaboration, and networking for people working with AI agent frameworks, tools, and infrastructure.
+
+::: warning AgentCon 2027 is invite-only
+AgentCon 2027 events are organized jointly by Global AI HQ and invited chapter leads and/or local organizers. Global AI HQ selects the locations and co-organizing teams. Open organizer applications are not available.
+
+The [Global AI Conference](/global-ai-conference/) replaces AgentCon as the open, chapter-organized conference format for 2027.
+:::
 
 The goal of AgentCon is to:
 
@@ -15,7 +21,7 @@ The goal of AgentCon is to:
 
 ## Purpose of this Guide
 
-This guide is designed for **Global AI Chapter Leads** and organizers who will host an **AgentCon** event. It includes:
+This guide is designed for invited **Global AI Chapter Leads** and/or local organizers co-organizing an **AgentCon 2027** event with Global AI HQ. It includes:
 
 - Rules and requirements set by Global AI HQ.  
 - Planning timelines and checklists.  
@@ -25,10 +31,9 @@ This guide is designed for **Global AI Chapter Leads** and organizers who will h
 
 ## Organizer Commitment
 
-By agreeing to host an **AgentCon**, you commit to:
+By accepting an invitation to co-organize **AgentCon 2027** with Global AI HQ, you commit to:
 
 - Following the fixed AgentCon format.  
 - Upholding diversity, inclusion, and accessibility standards.  
 - Ensuring all branding and materials follow official guidelines.  
 - Coordinating regularly with Global AI HQ.  
-

--- a/agentcon/sponsors.md
+++ b/agentcon/sponsors.md
@@ -1,5 +1,5 @@
-# Sponsors
+# AgentCon 2027 Sponsors
 
-For full details on AgentCon sponsorship tiers, benefits, and guidelines, see the [AgentCon Sponsorship page](/partnerships/agentcon-sponsorship).
+For full details on AgentCon 2027 sponsorship benefits and guidelines, see the [AgentCon 2027 Sponsorship page](/partnerships/agentcon-sponsorship).
 
 For questions, reach out to **[hq@globalai.community](mailto:hq@globalai.community)**.

--- a/event-format.md
+++ b/event-format.md
@@ -15,11 +15,13 @@ The Global AI Community offers several event formats you can pick up and run in 
 | [The Global AI Conference](/global-ai-conference/) | Conference | All year | Full day | High |
 | [Global AI Construct](/construct.md) | Hands-on workshop | 1 July – 30 September 2026 | 2 hours | Low |
 
+In 2027, the **Global AI Conference** replaces AgentCon as the conference format that chapters can apply to organize. **AgentCon 2027 is invite-only.**
+
 ## Past formats
 
 | Event | Style | Time frame | Duration | Effort |
 | --- | --- | --- | --- | --- |
-| [AgentCon](/agentcon/) | Conference | 1 September – 15 December | Full day | High |
+| [AgentCon open chapter format](/agentcon/) | Conference | 2025–2026 | Full day | High |
 | [Build //LOCALHOST](/build/organize.md) | MeetUp | Within 21 days after Build | 3–4 hours (Evening) | Low |
 | [Global AI Bootcamp](/agentcamp/index.md) | MeetUp/Conference | 15 February – 15 April 2026 | 2–8 hours | Medium–High |
 
@@ -30,12 +32,14 @@ A low-key evening MeetUp focused on AI agents. Run a hands-on workshop or give a
 
 ### [AI Community Day](/ai-community-day.md)
 A larger half-day MeetUp ("MeetUp XXL") with multiple sessions and more attendees. A step up from a regular evening event.
-The Global AI Conference](/global-ai-conference/)
-A full-day developer conference with a session track and a workshop track, a Microsoft keynote, and sponsors. The highest-effort format, run to a fixed global format.
 
-### [
-### [AgentCon](/agentcon/)
-A full-day conference format with speakers, tracks, and sponsors. The highest-effort format, run within a defined time frame.
+### [The Global AI Conference](/global-ai-conference/)
+
+A full-day developer conference with a session track and a workshop track, a Microsoft keynote, and sponsors. This is the open chapter-organized conference format for 2027.
+
+### [AgentCon 2027](/agentcon/)
+
+An invite-only, full-day developer conference focused on AI agents, with speakers, workshops, and sponsors.
 
 ### [Global AI Bootcamp (AgentCamp)](/agentcamp/index.md)
 A hands-on learning event combining MeetUp and conference styles, using your own or pre-made content.

--- a/global-ai-conference/index.md
+++ b/global-ai-conference/index.md
@@ -5,6 +5,10 @@ outline: deep
 
 [The Global AI Conference](https://globalai.community/) is a global developer conference focused on AI, built by developers, for developers. It is part of the Global AI Community and provides hands-on learning, collaboration, and networking around AI frameworks, tools, and infrastructure.
 
+::: info Open conference format for 2027
+The Global AI Conference replaces AgentCon as the open, chapter-organized conference format for 2027. AgentCon 2027 is a separate invite-only series.
+:::
+
 **Goals:** empower developers to build and deploy real-world AI, showcase the latest innovations, and foster collaboration between local developer communities worldwide.
 
 This guide is for **Global AI Chapter Leads** and organizers hosting a **Global AI Conference**. It covers rules and requirements, planning timelines, branding, logistics, communication, and practical execution tips.

--- a/global-ai-conference/post-event.md
+++ b/global-ai-conference/post-event.md
@@ -20,7 +20,7 @@ outline: deep
 
 ## Sponsors
 
-For sponsorship tiers, benefits, and guidelines, see the [AgentCon Sponsorship page](/partnerships/agentcon-sponsorship).
+For partnership and sponsorship options, see the [Global AI Community partnership overview](/partnerships/overview).
 
 ## Contact
 

--- a/partnerships/agentcon-sponsorship.md
+++ b/partnerships/agentcon-sponsorship.md
@@ -1,10 +1,10 @@
-# AgentCon Sponsorship
+# AgentCon 2027 Sponsorship
 
 ## Purpose
 
-AgentCon Sponsorship enables organizations to support local [AgentCon](http://agentcon.dev/) events — the Global AI Community's developer conference focused on AI Agents — while gaining targeted visibility and engagement with an audience of AI developers, data scientists, and professionals.
+AgentCon 2027 Sponsorship enables organizations to support invited local [AgentCon](http://agentcon.dev/) events — the Global AI Community's developer conference focused on AI Agents — while gaining targeted visibility and engagement with an audience of AI developers, data scientists, and professionals.
 
-AgentCon events are free for attendees, attracting a minimum of **150 participants** per event across multiple global waves. Sponsors play a vital role in making these high-quality, community-driven conferences possible.
+AgentCon 2027 events are free for attendees, attracting a minimum of **150 participants** per event. Sponsors play a vital role in making these high-quality, community-driven conferences possible.
 
 ## Why Sponsor AgentCon?
 
@@ -16,7 +16,7 @@ AgentCon events are free for attendees, attracting a minimum of **150 participan
 
 ## Sponsorship Benefits
 
-Sponsorship covers a series of AgentCon events over an agreed period. Sponsors receive the following benefits per event:
+Sponsorship covers a series of AgentCon 2027 events over an agreed period. Sponsors receive the following benefits per event:
 
 ### Speaking Session or Workshop
 - A dedicated speaking session (25 or 45 minutes depending on the event format), or
@@ -60,7 +60,7 @@ Sponsorship covers a series of AgentCon events over an agreed period. Sponsors r
 
 The sponsorship fee is **€3,000 per event**.
 
-Sponsors committing to **6 or more events** are recognized as a **Global AgentCon Sponsor**, gaining additional visibility across the entire AgentCon programme.
+Sponsors committing to **6 or more events** are recognized as a **Global AgentCon 2027 Sponsor**, gaining additional visibility across the entire AgentCon 2027 programme.
 
 ## How to Become a Sponsor
 1. Contact **[hq@globalai.community](mailto:hq@globalai.community)** to express interest.

--- a/partnerships/overview.md
+++ b/partnerships/overview.md
@@ -35,9 +35,9 @@ A custom, multi-year collaboration focused on shared goals, measurable impact, a
 
 ## Event Sponsorship
 
-### AgentCon Sponsorship
+### AgentCon 2027 Sponsorship
 
-Dedicated sponsorship opportunities for AgentCon — the Global AI Community's developer conference on AI Agents.
+Dedicated sponsorship opportunities for the invite-only AgentCon 2027 series — the Global AI Community's developer conference on AI Agents.
 
 [Read more](./agentcon-sponsorship.md)
 
@@ -69,7 +69,7 @@ We coordinate approved offers across relevant chapters, events, or programs so t
 | Partner | €6,000 per year |
 | Strategic Partner | Custom multi-year agreement |
 | Global AI Weekly | €500 per article, per edition |
-| AgentCon Sponsorship | €3,000 per event |
+| AgentCon 2027 Sponsorship | €3,000 per event |
 
 ## Interested?
 

--- a/partnerships/partnership-proposal.md
+++ b/partnerships/partnership-proposal.md
@@ -15,10 +15,10 @@ head:
 
 The Global AI Community connects **250,000+ members through 200+ chapters worldwide**. Our ecosystem includes a chapter and event platform, Global AI Weekly with **70,000+ subscribers**, a YouTube channel with **50,000+ subscribers**, global event programs, and local communities on every continent.
 
-This proposal gives the Partner a year-round global presence and direct engagement with AI developers through six AgentCon events. It combines:
+This proposal gives the Partner a year-round global presence and direct engagement with AI developers through six AgentCon 2027 events. It combines:
 
 1. A complimentary annual Global AI Community Partner package with specific content, product, social, and event-platform deliverables.
-2. Six AgentCon sponsorships, qualifying the organization as a **Global AgentCon Sponsor**.
+2. Six AgentCon 2027 sponsorships, qualifying the organization as a **Global AgentCon 2027 Sponsor**.
 
 The standard combined value is **€24,000**. The proposed investment is **€18,000**, with the €6,000 annual Partner fee fully waived.
 
@@ -37,7 +37,7 @@ The partnership is designed to:
 | Component | Included scope | Standard price | Proposed price |
 | --- | --- | ---: | ---: |
 | Global AI Community Partner | 12-month package | €6,000 | €0 |
-| Global AgentCon Sponsor | 6 events at €3,000 each | €18,000 | €18,000 |
+| Global AgentCon 2027 Sponsor | 6 events at €3,000 each | €18,000 | €18,000 |
 | **Total** | **1 annual partnership and 6 events** | **€24,000** | **€18,000** |
 
 ## 1. Annual Global AI Community Partner Package
@@ -52,18 +52,17 @@ The Partner receives the following benefits for the full proposal term. These de
 | **Short technical series** | One series about the Partner's company, product, or service; each episode provides a concise technical insight, practical tip, capability, or use case; scripts and publication dates agreed in advance | Up to 4 episodes of no more than 30 minutes each |
 | **Optional in-person interview** | An additional interview may be recorded when schedules and locations align | Optional; not a guaranteed deliverable |
 | **Global social media** | Posts across agreed Global AI Community-owned channels supporting the partnership, content, product campaign, technical series, or another agreed initiative | 6 posts during the term |
-| **Product and services campaign** | One coordinated offer of credits, vouchers, licenses, subscriptions, cloud or API access, developer tools, training resources, or professional services through agreed community channels | 1 campaign with audience, channels, timing, eligibility, and redemption process agreed before launch |
-| **Event organizing tools** | Access to public event publishing, attendee registration, capacity management, attendee communications, and digital badges | 1 approved Partner event series during the term |
+| **Product and services event campaign** | One coordinated campaign built around an approved Partner event series. The Partner may offer credits, vouchers, licenses, subscriptions, cloud or API access, developer tools, training resources, or professional services. The series includes access to public event publishing, attendee registration, capacity management, attendee communications, and digital badges, with promotion through agreed community channels. | 1 campaign and event series during the term; audience, schedule, channels, eligibility, and redemption process agreed before launch |
 
 All content, campaign, and event-series plans require prior agreement and must align with the Global AI Community's educational mission and brand policies. The Global AI Community manages distribution and does not provide the Partner with community member contact details or mailing-list access.
 
-## 2. Global AgentCon Sponsorship
+## 2. Global AgentCon 2027 Sponsorship
 
-The Partner will sponsor six AgentCon events selected and scheduled by mutual agreement during the proposal term. Each AgentCon is designed for at least 150 participants, creating an expected aggregate audience of at least **900 attendee places** across the six events.
+The Partner will sponsor six AgentCon 2027 events organized jointly by Global AI HQ and invited chapter leads and/or local organizers. Event locations must be selected from the published [AgentCon 2027 events list](/agentcon/events) and are confirmed by mutual agreement based on availability. The current suggested pool includes Bengaluru, Bangkok, Toronto, New York, Silicon Valley, Ottawa, Melbourne, Hong Kong, Tokyo, Berlin, and Amsterdam, from which six locations will be selected. Each AgentCon 2027 event is designed for at least 150 participants, creating an expected aggregate audience of at least **900 attendee places** across the six events.
 
 ### Guaranteed Aggregate Deliverables
 
-Across the six sponsored AgentCon events, the Partner receives:
+Across the six sponsored AgentCon 2027 events, the Partner receives:
 
 | Deliverable | Total included |
 | --- | ---: |
@@ -77,11 +76,11 @@ Across the six sponsored AgentCon events, the Partner receives:
 | Event reports | 6 |
 | Access to event photo collections | 6 |
 
-### Global AgentCon Sponsor Recognition
+### Global AgentCon 2027 Sponsor Recognition
 
-The six-event commitment qualifies the Partner for **Global AgentCon Sponsor** status during the proposal term. This includes:
+The six-event commitment qualifies the Partner for **Global AgentCon 2027 Sponsor** status during the proposal term. This includes:
 
-- Use of the Global AgentCon Sponsor designation.
+- Use of the Global AgentCon 2027 Sponsor designation.
 - Logo and name recognition on the central AgentCon sponsor page.
 - Recognition in applicable program-wide AgentCon sponsor communications and materials.
 - Coordination of the six-event portfolio through Global AI Community HQ.
@@ -93,8 +92,7 @@ The Global AI Community will maintain a delivery record for the agreed benefits.
 - Links to the four published Global AI Weekly articles.
 - Links to the published technical series episodes and, if produced, the optional in-person interview.
 - Links or screenshots for the six annual Partner social posts.
-- A summary of the product and services campaign and the channels used.
-- Confirmation of the approved Partner event series and enabled platform capabilities.
+- A summary of the product and services event campaign, channels used, approved event series, and enabled platform capabilities.
 - An event report and photo link for each sponsored AgentCon.
 - A final summary of delivered activities and reported aggregate AgentCon attendance.
 
@@ -136,7 +134,7 @@ Invoicing and payment timing will be defined in the written agreement.
 
 ## Conditions and Safeguards
 
-- The parties will confirm the selected AgentCon events and schedule in writing.
+- The parties will confirm the selected AgentCon 2027 events and schedule in writing.
 - Branding assets and session or workshop materials must be supplied at least four weeks before each event.
 - Sessions and sponsored content are subject to review for alignment with the Global AI Community's educational mission.
 - The organization must follow the Global AI Community Code of Conduct, sponsorship guidelines, and brand policies.
@@ -150,8 +148,8 @@ Invoicing and payment timing will be defined in the written agreement.
 ## Next Steps
 
 1. Confirm acceptance of the proposed scope and €18,000 investment.
-2. Select the six AgentCon events.
-3. Agree on the Partner content calendar, product campaign, and event series.
+2. Select the six AgentCon 2027 events.
+3. Agree on the Partner content calendar and product and services event campaign.
 4. Complete the written partnership and sponsorship agreement.
 5. Schedule a kickoff meeting and begin delivery.
 


### PR DESCRIPTION
## Summary
- restructure AgentCon navigation around Events, Guide, and Sponsors
- define AgentCon 2027 as an invite-only HQ and local co-organized series
- direct open chapter conference applications to Global AI Conference
- add confirmed and proposed AgentCon event locations
- align sponsorship and partnership proposal language with AgentCon 2027