### PR TITLE
Update AgentCon 2027 locations

### DIFF
--- a/agentcon/events.md
+++ b/agentcon/events.md
@@ -24,6 +24,8 @@ The following invite-only locations are being considered for AgentCon 2027 and t
 | --- | --- |
 | 30 January 2027 | Bengaluru, India |
 | 6 February 2027 | Bangkok, Thailand |
+| 25 February 2027 | Houston, United States |
+| 27 February 2027 | Dallas, United States |
 | 3 April 2027 | Toronto, Canada |
 | 6 April 2027 | New York, United States |
 | 9 April 2027 | Silicon Valley, United States |
@@ -31,5 +33,5 @@ The following invite-only locations are being considered for AgentCon 2027 and t
 | May 2027 | Melbourne, Australia |
 | May 2027 | Hong Kong |
 | May 2027 | Tokyo, Japan |
-| June 2027 | Berlin, Germany |
+| 22 June 2027 | Berlin, Germany |
 | June 2027 | Amsterdam, Netherlands |

--- a/agentcon/events.md
+++ b/agentcon/events.md
@@ -34,4 +34,4 @@ The following invite-only locations are being considered for AgentCon 2027 and t
 | May 2027 | Hong Kong |
 | May 2027 | Tokyo, Japan |
 | 22 June 2027 | Berlin, Germany |
-| June 2027 | Amsterdam, Netherlands |
+| 24 June 2027 | Amsterdam, Netherlands |

--- a/partnerships/partnership-proposal.md
+++ b/partnerships/partnership-proposal.md
@@ -62,7 +62,7 @@ We will work together on the topics, audience, schedule, channels, and format. O
 
 The Partner will sponsor six AgentCon 2027 events. AgentCon events are organized jointly by Global AI Community HQ and invited chapter leads and/or local organizers.
 
-The Partner can share its preferred locations from the [AgentCon 2027 event list](/agentcon/events). We will then build the final six-event portfolio together, based on availability, local readiness, venue capacity, timing, geographic balance, and the Partner’s priorities.
+The Partner can share its preferred locations from the [AgentCon 2027 event list](/agentcon/events), including Bengaluru, Bangkok, Houston, Dallas, Toronto, New York, Silicon Valley, Ottawa, Melbourne, Hong Kong, Tokyo, Berlin, and Amsterdam. We will then build the final six-event portfolio together, based on availability, local readiness, venue capacity, timing, geographic balance, and the Partner’s priorities.
 
 Each event targets **300 developers**, creating a combined target of **1,800 attendee places** across six events. This is an event-planning target; actual registrations and attendance will vary by location.
 


### PR DESCRIPTION
## Summary
- add Houston and Dallas to the proposed AgentCon 2027 locations
- set Berlin to 22 June 2027
- set Amsterdam to 24 June 2027
- align the partnership proposal location list